### PR TITLE
Fixed Rocket.pde of EvolveFlowField: ArrayIndexOutOfBoundsException

### DIFF
--- a/Processing/chp9_ga/EvolveFlowField/Rocket.pde
+++ b/Processing/chp9_ga/EvolveFlowField/Rocket.pde
@@ -106,7 +106,7 @@ class Rocket {
 
       // Get the steering vector out of our genes in the right spot
       // We could do (desired - velocity) to be more in line with the Reynolds flow field following
-      acceleration.add(dna.genes[x+y*width/gridscale]);
+      acceleration.add(dna.genes[x+y*(width/gridscale)]);
 
       // This is all the same stuff we've done before
       acceleration.mult(maxforce);


### PR DESCRIPTION
When I ran this example and some rockets came to the bottom right corner of the window, it threw an `ArrayIndexOutOfBoundsException` at that line.

Actually
`y*(width/gridscale)`should be the same as
`y*width/gridscale`.

But as `y` is of type `Integer`, it behaves differently and causes an `ArrayIndexOutOfBoundsException`.

With the brackets around `width/gridscale` it is the same term as for the instantiation of the array
`dnasize = (width / gridscale) * (height / gridscale);`

So I think it should be save that way.
