### PR TITLE
Cut redundant noStroke()

### DIFF
--- a/Processing/introduction/NOC_I_4_Gaussian/NOC_I_4_Gaussian.pde
+++ b/Processing/introduction/NOC_I_4_Gaussian/NOC_I_4_Gaussian.pde
@@ -16,7 +16,6 @@ void draw() {
   float mean = width/2;         // Define a mean value (middle of the screen along the x-axis)
   xloc = ( xloc * sd ) + mean;  // Scale the gaussian random number by standard deviation and mean
 
-  noStroke();
   fill(0, 10);
   noStroke();
   ellipse(xloc, height/2, 16, 16);   // Draw an ellipse at our "normal" random location


### PR DESCRIPTION
It's not necessary to have both noStroke() methods here; just one will do. :)

Also, the code snippet in the text uses white circles:

```
fill(255,10);
```

…but the code example uses black circles on a while background:

```
fill(0, 10);
```

It may be useful to either change the example here and screenshot to sync up, or change the text snippet.
