### PR TITLE
Add JRubyArt port for processing-3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This is the repository for example [Processing](http://processing.org) code from
 * [hardmaru's paper.js port of box2d physics lib examples](https://github.com/hardmaru/paperjs_box2d)([online demo](http://otoro.net/paperbox/))
 
 ### Ruby
-* [Ruby-processing port](https://github.com/ruby-processing/The-Nature-of-Code-Examples-in-Ruby)
+* [Ruby-processing port](https://github.com/ruby-processing/The-Nature-of-Code-Examples-in-Ruby) for processing-2.2.1
+* [JRubyArt port](https://github.com/ruby-processing/The-Nature-of-Code-for-JRubyArt) for processing-3.0+
 
 ### Other
 * [Clojure / Quil](https://github.com/sjl/The-Nature-of-Code-Examples)


### PR DESCRIPTION
JRubyArt is a replacement for ruby-processing for use with processing-3.0. For the most part the examples needed to be changed (to include a settings method, where size, smooth etc now live).  But there are other changes to make use of ruby-2.1+ syntax (JRuby-9.0.3.0) not available with ruby-processing (JRuby-1.7.xx ruby-1.9.3 syntax).