### PR TITLE
Removes 'times' from size()

### DIFF
--- a/chp06_agents/NOC_6_04_Flow_Figures/NOC_6_04_Flow_Figures.pde
+++ b/chp06_agents/NOC_6_04_Flow_Figures/NOC_6_04_Flow_Figures.pde
@@ -12,7 +12,7 @@ PShape arrow;
 PImage a;
 
 void setup() {
-  size(1800, 60*9);
+  size(1800, 540);
   // Make a new flow field with "resolution" of 16
   flowfield = new FlowField(60);
   arrow = loadShape("arrow.svg");


### PR DESCRIPTION
Processing (3.1.2, Linux) complains you can only use numbers in size()