### PR TITLE
Fixed dragging pendulum

### DIFF
--- a/chp03_oscillation/NOC_3_10_PendulumExample/Pendulum.pde
+++ b/chp03_oscillation/NOC_3_10_PendulumExample/Pendulum.pde
@@ -81,8 +81,10 @@ class Pendulum {
 
   // This tells us we are not longer clicking on the ball
   void stopDragging() {
-    aVelocity = 0; // No velocity once you let go
-    dragging = false;
+    if (dragging) {
+      aVelocity = 0; // No velocity once you let go
+      dragging = false;
+    }
   }
 
   void drag() {


### PR DESCRIPTION
Hi Dan!

I noticed on "The Nature of Code" website, that if you click anywhere on the "Example 3.10: Swinging pendulum" window, the pendulum will lose its speed, because of setting `aVelocity` to 0 in `stopDragging()` function. So I just added `if (dragging)`, which fixes this problem :)

Thank you for the book and YouTube channel (I'm making this pull request thanks to your "Git and GitHub for Poets" tutorial), cheers!