### PR TITLE
Fixes Issue #83 : variable naming in Collision Equal Mass

### DIFF
--- a/chp05_physicslibraries/CollisionsEqualMass/Mover.pde
+++ b/chp05_physicslibraries/CollisionsEqualMass/Mover.pde
@@ -65,20 +65,20 @@ class Mover {
     float sumR = r + other.r;
     // Are they colliding?
     if (!colliding && d < sumR) {
-      // Yes, make new veposities!
+      // Yes, make new velocities!
       colliding = true;
       // Direction of one object another
       PVector n = PVector.sub(other.pos,pos);
       n.normalize();
 
-      // Difference of veposities so that we think of one object as stationary
+      // Difference of velocities so that we think of one object as stationary
       PVector u = PVector.sub(vel,other.vel);
 
       // Separate out components -- one in direction of normal
       PVector un = componentVector(u,n);
       // Other component
       u.sub(un);
-      // These are the new veposities plus the veposity of the object we consider as stastionary
+      // These are the new velocities plus the velocity of the object we consider as stastionary
       vel = PVector.add(u,other.vel);
       other.vel = PVector.add(un,other.vel);
     } 

--- a/chp05_physicslibraries/CollisionsEqualMass/Mover.pde
+++ b/chp05_physicslibraries/CollisionsEqualMass/Mover.pde
@@ -14,7 +14,7 @@ class Mover {
 
   Mover(PVector v, PVector l) {
     vel = v.get();
-    loc = l.get();
+    pos = l.get();
   }
 
   // Main method to operate object
@@ -56,29 +56,29 @@ class Mover {
     fill(175,200);
     ellipse(pos.x,pos.y,r*2,r*2);
     if (showVectors) {
-      drawVector(vel,loc,10);
+      drawVector(vel,pos,10);
     }
   }
 
   void collideEqualMass(Mover other) {
-    float d = PVector.dist(loc,other.loc);
+    float d = PVector.dist(pos,other.pos);
     float sumR = r + other.r;
     // Are they colliding?
     if (!colliding && d < sumR) {
-      // Yes, make new velocities!
+      // Yes, make new veposities!
       colliding = true;
       // Direction of one object another
-      PVector n = PVector.sub(other.loc,loc);
+      PVector n = PVector.sub(other.pos,pos);
       n.normalize();
 
-      // Difference of velocities so that we think of one object as stationary
+      // Difference of veposities so that we think of one object as stationary
       PVector u = PVector.sub(vel,other.vel);
 
       // Separate out components -- one in direction of normal
       PVector un = componentVector(u,n);
       // Other component
       u.sub(un);
-      // These are the new velocities plus the velocity of the object we consider as stastionary
+      // These are the new veposities plus the veposity of the object we consider as stastionary
       vel = PVector.add(u,other.vel);
       other.vel = PVector.add(un,other.vel);
     } 
@@ -96,5 +96,3 @@ PVector componentVector (PVector vector, PVector directionVector) {
   directionVector.mult(vector.dot(directionVector));
   return directionVector;
 }
-
-


### PR DESCRIPTION
The Collision Equal Mass example wasn't running due to errors in variable nomenclature. This commit fixes this minor bug.